### PR TITLE
Migrate to FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This project is an implementation of "Clean architecture" in combining:
 - [Dishka](https://github.com/reagento/dishka)
 - [FastStream](https://github.czom/ag2ai/faststream)
 
+> ⚡ Почему FastAPI?\
+Исходный шаблон был на Litestar, но со временем интерес к нему угас и он встречается редко. Мы мигрировали на FastAPI — де-факто стандарт для HTTP API на Python.
+
 ## Architecture Overview
 
 - [Пишем универсальный прототип бэкенд-приложения](https://habr.com/ru/companies/pt/articles/820171/)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is an implementation of "Clean architecture" in combining:
 - [FastStream](https://github.czom/ag2ai/faststream)
 
 > ⚡ **Why FastAPI?**\
-The original template was built with Litestar, but over time interest in it has faded and it's rarely used in real projects. The project has been migrated to FastAPI — the de facto standard for building HTTP APIs in Python.
+The original example application was built using the Litestar framework. However, as the framework evolved, it took a rather specific development direction, so we decided to rewrite the materials using FastAPI. As of today, it is the most optimal framework choice for working with HTTP.
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This project is an implementation of "Clean architecture" in combining:
 - [Dishka](https://github.com/reagento/dishka)
 - [FastStream](https://github.czom/ag2ai/faststream)
 
-> ⚡ Почему FastAPI?\
-Исходный шаблон был на Litestar, но со временем интерес к нему угас и он встречается редко. Мы мигрировали на FastAPI — де-факто стандарт для HTTP API на Python.
+> ⚡ **Why FastAPI?**\
+The original template was built with Litestar, but over time interest in it has faded and it's rarely used in real projects. The project has been migrated to FastAPI — the de facto standard for building HTTP APIs in Python.
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Litestar-Dishka-FastStream
+# FastAPI-Dishka-FastStream
 
 [![License - MIT](https://img.shields.io/badge/license-MIT-202235.svg?logo=python&labelColor=202235&color=edb641&logoColor=edb641)](https://spdx.org/licenses/)
-[![Litestar Project](https://img.shields.io/badge/Litestar%20Org-%E2%AD%90%20Litestar-202235.svg?logo=python&labelColor=202235&color=edb641&logoColor=edb641)](https://github.com/litestar-org/litestar)
+[![FastAPI](https://img.shields.io/badge/FastAPI-009485.svg?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![FastStream](https://camo.githubusercontent.com/4bbf0095f52083ac1b693fdab68466f859b674aeef4bcb5c92fb0c087812dfc0/68747470733a2f2f696d672e736869656c64732e696f2f656e64706f696e743f75726c3d68747470732533412532462532467261772e67697468756275736572636f6e74656e742e636f6d25324661673261692532466661737473747265616d2532466d61696e253246646f6373253246646f6373253246617373657473253246696d67253246736869656c642e6a736f6e)](https://faststream.ag2.ai/latest/)
 [![Dishka](https://img.shields.io/badge/Dishka-1.4.2+-green)](https://github.com/reagento/dishka)
 
 This project is an implementation of "Clean architecture" in combining:
-- [Litestar](https://github.com/litestar-org/litestar)
+- [FastAPI](https://github.com/fastapi/fastapi)
 - [Dishka](https://github.com/reagento/dishka)
-- [FastStream](https://github.com/ag2ai/faststream)
+- [FastStream](https://github.czom/ag2ai/faststream)
 
 ## Architecture Overview
 
@@ -58,7 +58,7 @@ _but you also can run HTTP API only or AMQP consumer only_
 
 ```shell
 // HTTP API Only
-uvicorn --factory book_club.main:get_litestar_app --reload
+uvicorn --factory book_club.main:get_fastapi_app --reload
 
 // AMQP Consumer Only
 faststream run --factory book_club.main:get_faststream_app --reload

--- a/book_club/controllers/amqp.py
+++ b/book_club/controllers/amqp.py
@@ -1,4 +1,4 @@
-from dishka.integrations.base import FromDishka as Depends
+from dishka.integrations.faststream import FromDishka
 from faststream.rabbit import RabbitRouter
 
 from book_club.application.dto import NewBookDTO
@@ -10,7 +10,7 @@ AMQPBookController = RabbitRouter()
 
 @AMQPBookController.subscriber("create_book")
 @AMQPBookController.publisher("book_statuses")
-async def handle(data: BookSchema, interactor: Depends[NewBookInteractor]) -> str:
+async def handle(data: BookSchema, interactor: FromDishka[NewBookInteractor]) -> str:
     dto = NewBookDTO(title=data.title, pages=data.pages, is_read=data.is_read)
     uuid = await interactor(dto)
     return uuid

--- a/book_club/controllers/http.py
+++ b/book_club/controllers/http.py
@@ -1,18 +1,17 @@
 from typing import Annotated
 from uuid import UUID
 
-from dishka.integrations.fastapi import FromDishka, inject
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
 from fastapi import APIRouter, HTTPException, Path, status
 
 from book_club.application.interactors import GetBookInteractor
 from book_club.controllers.schemas import BookSchema
 
 
-book_router = APIRouter(prefix="/book")
+book_router = APIRouter(prefix="/book", route_class=DishkaRoute)
 
 
 @book_router.get("/{book_id:uuid}")
-@inject
 async def get_book(
     book_id: Annotated[UUID, Path(description="Book ID", title="Book ID")],
     interactor: FromDishka[GetBookInteractor],

--- a/book_club/controllers/http.py
+++ b/book_club/controllers/http.py
@@ -1,8 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from dishka.integrations.fastapi import FromDishka
-from dishka.integrations.fastapi import inject
+from dishka.integrations.fastapi import FromDishka, inject
 from fastapi import APIRouter, HTTPException, Path, status
 
 from book_club.application.interactors import GetBookInteractor

--- a/book_club/controllers/http.py
+++ b/book_club/controllers/http.py
@@ -1,9 +1,9 @@
 from typing import Annotated
 from uuid import UUID
 
-from dishka.integrations.fastapi import FromDishka as Depends
+from dishka.integrations.fastapi import FromDishka
 from dishka.integrations.fastapi import inject
-from fastapi import APIRouter, Body, HTTPException, Path, status
+from fastapi import APIRouter, HTTPException, Path, status
 
 from book_club.application.interactors import GetBookInteractor
 from book_club.controllers.schemas import BookSchema
@@ -16,7 +16,7 @@ book_router = APIRouter(prefix="/book")
 @inject
 async def get_book(
     book_id: Annotated[UUID, Path(description="Book ID", title="Book ID")],
-    interactor: Depends[GetBookInteractor],
+    interactor: FromDishka[GetBookInteractor],
 ) -> BookSchema:
     book_dm = await interactor(uuid=str(book_id))
 

--- a/book_club/controllers/http.py
+++ b/book_club/controllers/http.py
@@ -1,34 +1,33 @@
 from typing import Annotated
 from uuid import UUID
-from http import HTTPStatus
 
-from dishka.integrations.base import FromDishka as Depends
-from dishka.integrations.litestar import inject
-from litestar import Controller, route, HttpMethod
-from litestar.exceptions import HTTPException
-from litestar.params import Body
+from dishka.integrations.fastapi import FromDishka as Depends
+from dishka.integrations.fastapi import inject
+from fastapi import APIRouter, Body, HTTPException, Path, status
 
 from book_club.application.interactors import GetBookInteractor
 from book_club.controllers.schemas import BookSchema
 
 
-class HTTPBookController(Controller):
-    path = "/book"
+book_router = APIRouter(prefix="/book")
 
-    @route(http_method=HttpMethod.GET, path="/{book_id:uuid}")
-    @inject
-    async def get_book(
-        self,
-        book_id: Annotated[UUID, Body(description="Book ID", title="Book ID")],
-        interactor: Depends[GetBookInteractor],
-    ) -> BookSchema:
-        book_dm = await interactor(uuid=str(book_id))
-        if not book_dm:
-            raise HTTPException(
-                status_code=HTTPStatus.NOT_FOUND, detail="Book not found"
-            )
-        return BookSchema(
-            title=book_dm.title,
-            pages=book_dm.pages,
-            is_read=book_dm.is_read,
+
+@book_router.get("/{book_id:uuid}")
+@inject
+async def get_book(
+    book_id: Annotated[UUID, Path(description="Book ID", title="Book ID")],
+    interactor: Depends[GetBookInteractor],
+) -> BookSchema:
+    book_dm = await interactor(uuid=str(book_id))
+
+    if not book_dm:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Book not found"
         )
+
+    return BookSchema(
+        title=book_dm.title,
+        pages=book_dm.pages,
+        is_read=book_dm.is_read,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pydantic==2.12.2
 faststream[cli,rabbit]==0.6.1
 dishka==1.7.2
 dishka-faststream==0.5.0
-litestar==2.18.0
+fastapi==0.119.1
 uvicorn==0.37.0
 SQLAlchemy[asyncio]==2.0.44
 alembic==1.17.0
@@ -13,3 +13,4 @@ watchfiles==1.1.1
 pytest==8.4.2
 pytest-asyncio==1.2.0
 Faker==37.11.0
+httpx==0.28.1


### PR DESCRIPTION
⚡ **Why FastAPI?**

The original example application was built using the Litestar framework. However, as the framework evolved, it took a rather specific development direction, so we decided to rewrite the materials using FastAPI. As of today, it is the most optimal framework choice for working with HTTP.