### PR TITLE
🚽 Remove unused flush

### DIFF
--- a/book_club/application/interfaces.py
+++ b/book_club/application/interfaces.py
@@ -22,6 +22,3 @@ class UUIDGenerator(Protocol):
 class DBSession(Protocol):
     @abstractmethod
     async def commit(self) -> None: ...
-
-    @abstractmethod
-    async def flush(self) -> None: ...


### PR DESCRIPTION
Remove unused `flush` method from the `DBSession` interface